### PR TITLE
Add Insurance.move and enclave.move

### DIFF
--- a/crates/mys-framework/packages/mys-social/sources/bootstrap.move
+++ b/crates/mys-framework/packages/mys-social/sources/bootstrap.move
@@ -59,7 +59,6 @@ module social_contracts::bootstrap {
         transfer::public_transfer(mydata::create_mydata_admin_cap(ctx), admin);
         transfer::public_transfer(social_proof_of_truth::create_spot_admin_cap(ctx), admin);
         transfer::public_transfer(social_proof_of_truth::create_spot_oracle_admin_cap(ctx), admin);
-        transfer::public_transfer(insurance::create_insurance_admin_cap(ctx), admin);
         transfer::public_transfer(coin::create_coin_creation_admin_cap_for_bootstrap(ctx), admin);
 
         // Seal the bootstrap key permanently (prevents any future bootstrap attempts)

--- a/crates/mys-framework/packages/mys-social/sources/bootstrap.move
+++ b/crates/mys-framework/packages/mys-social/sources/bootstrap.move
@@ -21,6 +21,7 @@ module social_contracts::bootstrap {
     use social_contracts::governance::{Self, GovernanceAdminCap};
     use social_contracts::mydata::{Self, MyDataAdminCap};
     use social_contracts::social_proof_of_truth::{Self, SpotAdminCap, SpotOracleAdminCap};
+    use social_contracts::insurance::{Self, InsuranceAdminCap};
     
     // Import framework coin module for coin creation admin cap
     use mys::coin::{Self, CoinCreationAdminCap};
@@ -46,6 +47,7 @@ module social_contracts::bootstrap {
         social_contracts::proof_of_creativity::bootstrap_init(ctx);
         social_contracts::message::bootstrap_init(ctx);
         social_contracts::social_proof_of_truth::bootstrap_init(ctx);
+        social_contracts::insurance::bootstrap_init(ctx);
         
         // Create admin capabilities
         transfer::public_transfer(upgrade::create_upgrade_admin_cap(ctx), admin);
@@ -57,6 +59,7 @@ module social_contracts::bootstrap {
         transfer::public_transfer(mydata::create_mydata_admin_cap(ctx), admin);
         transfer::public_transfer(social_proof_of_truth::create_spot_admin_cap(ctx), admin);
         transfer::public_transfer(social_proof_of_truth::create_spot_oracle_admin_cap(ctx), admin);
+        transfer::public_transfer(insurance::create_insurance_admin_cap(ctx), admin);
         transfer::public_transfer(coin::create_coin_creation_admin_cap_for_bootstrap(ctx), admin);
 
         // Seal the bootstrap key permanently (prevents any future bootstrap attempts)

--- a/crates/mys-framework/packages/mys-social/sources/enclave.move
+++ b/crates/mys-framework/packages/mys-social/sources/enclave.move
@@ -1,4 +1,4 @@
-// Copyright (c), Mysten Labs, Inc.
+// Copyright (c) The Social Proof Foundation, LLC.
 // SPDX-License-Identifier: Apache-2.0
 
 // Permissionless registration of an enclave.

--- a/crates/mys-framework/packages/mys-social/sources/enclave.move
+++ b/crates/mys-framework/packages/mys-social/sources/enclave.move
@@ -1,0 +1,219 @@
+// Copyright (c), Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Permissionless registration of an enclave.
+
+#[allow(duplicate_alias)]
+module social_contracts::enclave;
+
+use std::bcs;
+use std::string::String;
+use mys::ed25519;
+use mys::nitro_attestation::{Self, NitroAttestationDocument};
+use mys::{
+    object::{Self, UID, ID},
+    tx_context::{Self, TxContext},
+    transfer,
+};
+
+const EInvalidPCRs: u64 = 0;
+const EInvalidConfigVersion: u64 = 1;
+const EInvalidCap: u64 = 2;
+const EInvalidOwner: u64 = 3;
+
+// PCR0: Enclave image file
+// PCR1: Enclave Kernel
+// PCR2: Enclave application
+public struct Pcrs(vector<u8>, vector<u8>, vector<u8>) has copy, drop, store;
+
+// The expected PCRs.
+// - We only define the first 3 PCRs. One can define other
+//   PCRs and/or fields (e.g. user_data) if necessary as part
+//   of the config.
+// - See https://docs.aws.amazon.com/enclaves/latest/user/set-up-attestation.html#where
+//   for more information on PCRs.
+public struct EnclaveConfig<phantom T> has key {
+    id: UID,
+    name: String,
+    pcrs: Pcrs,
+    capability_id: ID,
+    version: u64, // Incremented when pcrs change. 
+}
+
+// A verified enclave instance, with its public key.
+public struct Enclave<phantom T> has key {
+    id: UID,
+    pk: vector<u8>,
+    config_version: u64, // Points to the EnclaveConfig's version.
+    owner: address,
+}
+
+// A capability to update the enclave config.
+public struct Cap<phantom T> has key, store {
+    id: UID,
+}
+
+// An intent message, used for wrapping enclave messages.
+public struct IntentMessage<T: drop> has copy, drop {
+    intent: u8,
+    timestamp_ms: u64,
+    payload: T,
+}
+
+/// Create a new `Cap` using a `witness` T from a module.
+public fun new_cap<T: drop>(_: T, ctx: &mut TxContext): Cap<T> {
+    Cap {
+        id: object::new(ctx),
+    }
+}
+
+public fun create_enclave_config<T: drop>(
+    cap: &Cap<T>,
+    name: String,
+    pcr0: vector<u8>,
+    pcr1: vector<u8>,
+    pcr2: vector<u8>,
+    ctx: &mut TxContext,
+) {
+    let enclave_config = EnclaveConfig<T> {
+        id: object::new(ctx),
+        name,
+        pcrs: Pcrs(pcr0, pcr1, pcr2),
+        capability_id: cap.id.to_inner(),
+        version: 0,
+    };
+
+    transfer::share_object(enclave_config);
+}
+
+public fun register_enclave<T>(
+    enclave_config: &EnclaveConfig<T>,
+    document: NitroAttestationDocument,
+    ctx: &mut TxContext,
+) {
+    let pk = load_pk(enclave_config, &document);
+
+    let _enclave = Enclave<T> {
+        id: object::new(ctx),
+        pk,
+        config_version: enclave_config.version,
+        owner: tx_context::sender(ctx),
+    };
+
+    transfer::share_object(_enclave);
+}
+
+public fun verify_signature<T, P: drop>(
+    enclave: &Enclave<T>,
+    intent_scope: u8,
+    timestamp_ms: u64,
+    payload: P,
+    signature: &vector<u8>,
+): bool {
+    let intent_message = create_intent_message(intent_scope, timestamp_ms, payload);
+    let payload = bcs::to_bytes(&intent_message);
+    return ed25519::ed25519_verify(signature, &enclave.pk, &payload)
+}
+
+public fun update_pcrs<T: drop>(
+    config: &mut EnclaveConfig<T>,
+    cap: &Cap<T>,
+    pcr0: vector<u8>,
+    pcr1: vector<u8>,
+    pcr2: vector<u8>,
+) {
+    cap.assert_is_valid_for_config(config);
+    config.pcrs = Pcrs(pcr0, pcr1, pcr2);
+    config.version = config.version + 1;
+}
+
+public fun update_name<T: drop>(config: &mut EnclaveConfig<T>, cap: &Cap<T>, name: String) {
+    cap.assert_is_valid_for_config(config);
+    config.name = name;
+}
+
+public fun pcr0<T>(config: &EnclaveConfig<T>): &vector<u8> {
+    &config.pcrs.0
+}
+
+public fun pcr1<T>(config: &EnclaveConfig<T>): &vector<u8> {
+    &config.pcrs.1
+}
+
+public fun pcr2<T>(config: &EnclaveConfig<T>): &vector<u8> {
+    &config.pcrs.2
+}
+
+public fun pk<T>(enclave: &Enclave<T>): &vector<u8> {
+    &enclave.pk
+}
+
+public fun destroy_old_enclave<T>(e: Enclave<T>, config: &EnclaveConfig<T>) {
+    assert!(e.config_version < config.version, EInvalidConfigVersion);
+    let Enclave { id, .. } = e;
+    id.delete();
+}
+
+public fun deploy_old_enclave_by_owner<T>(e: Enclave<T>, ctx: &mut TxContext) {
+    assert!(e.owner == tx_context::sender(ctx), EInvalidOwner);
+    let Enclave { id, .. } = e;
+    id.delete();
+}
+
+fun assert_is_valid_for_config<T>(cap: &Cap<T>, enclave_config: &EnclaveConfig<T>) {
+    assert!(cap.id.to_inner() == enclave_config.capability_id, EInvalidCap);
+}
+
+fun load_pk<T>(enclave_config: &EnclaveConfig<T>, document: &NitroAttestationDocument): vector<u8> {
+    assert!(to_pcrs(document) == enclave_config.pcrs, EInvalidPCRs);
+
+    let public_key_option = nitro_attestation::public_key(document);
+    assert!(option::is_some(public_key_option), EInvalidPCRs);
+    *option::borrow(public_key_option)
+}
+
+fun to_pcrs(document: &NitroAttestationDocument): Pcrs {
+    let pcrs_vec = nitro_attestation::pcrs(document);
+    // PCRs are stored in fixed order [0, 1, 2, 3, 4, 8] per native implementation
+    let pcr0_entry = vector::borrow(pcrs_vec, 0);
+    let pcr1_entry = vector::borrow(pcrs_vec, 1);
+    let pcr2_entry = vector::borrow(pcrs_vec, 2);
+    Pcrs(*nitro_attestation::value(pcr0_entry), *nitro_attestation::value(pcr1_entry), *nitro_attestation::value(pcr2_entry))
+}
+
+fun create_intent_message<P: drop>(intent: u8, timestamp_ms: u64, payload: P): IntentMessage<P> {
+    IntentMessage {
+        intent,
+        timestamp_ms,
+        payload,
+    }
+}
+
+#[test_only]
+public fun destroy<T>(enclave: Enclave<T>) {
+    let Enclave { id, .. } = enclave;
+    id.delete();
+}
+
+#[test_only]
+public struct SigningPayload has copy, drop {
+    location: String,
+    temperature: u64,
+}
+
+#[test]
+fun test_serde() {
+    // serialization should be consistent with rust test see `fn test_serde` in `src/nautilus-server/app.rs`.
+    let scope = 0;
+    let timestamp = 1744038900000;
+    let signing_payload = create_intent_message(
+        scope,
+        timestamp,
+        SigningPayload {
+            location: b"San Francisco".to_string(),
+            temperature: 13,
+        },
+    );
+    let bytes = bcs::to_bytes(&signing_payload);
+    assert!(bytes == x"0020b1d110960100000d53616e204672616e636973636f0d00000000000000", 0);
+}

--- a/crates/mys-framework/packages/mys-social/sources/insurance.move
+++ b/crates/mys-framework/packages/mys-social/sources/insurance.move
@@ -1,0 +1,722 @@
+// Copyright (c) The Social Proof Foundation, LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Insurance module for SPoT positions
+/// Sells coverage against losing outcomes and pays out deterministically on SPoT resolution.
+
+#[allow(duplicate_alias, unused_use, unused_const, unused_variable, lint(self_transfer, share_owned))]
+module social_contracts::insurance {
+    use std::option::{Self, Option};
+    use std::vector;
+
+    use mys::{
+        object::{Self, UID, ID},
+        tx_context::{Self, TxContext},
+        transfer,
+        clock::{Self, Clock},
+        coin::{Self, Coin},
+        balance::{Self, Balance},
+        table::{Self, Table},
+        event,
+    };
+    use mys::mys::MYS;
+
+    use social_contracts::social_proof_of_truth as spot;
+
+    /// Errors
+    const ENotAdmin: u64 = 1;
+    const EPaused: u64 = 2;
+    const EInvalidCoverage: u64 = 3;
+    const EInvalidDuration: u64 = 4;
+    const EInvalidAmount: u64 = 5;
+    const EInvalidVault: u64 = 6;
+    const EInsufficientCapital: u64 = 7;
+    const EMarketClosed: u64 = 8;
+    const EPolicyNotActive: u64 = 9;
+    const EPolicyExpired: u64 = 10;
+    const ENotPolicyOwner: u64 = 11;
+    const EOverflow: u64 = 12;
+    const EMarketMismatch: u64 = 13;
+    const EExposureLimit: u64 = 14;
+    const EInsufficientPremium: u64 = 15;
+
+    /// Status
+    const STATUS_ACTIVE: u8 = 1;
+    const STATUS_CANCELLED: u8 = 2;
+    const STATUS_CLAIMED: u8 = 3;
+    const STATUS_EXPIRED: u8 = 4;
+
+    /// Constants
+    const BPS_DENOM: u64 = 10_000;
+    const DAY_MS: u64 = 86_400_000;
+    const MAX_U64: u64 = 18446744073709551615;
+    const DEFAULT_VERSION: u64 = 1;
+    const DEFAULT_MIN_COVERAGE_BPS: u64 = 1000;
+    const DEFAULT_MAX_COVERAGE_BPS: u64 = 9000;
+    const DEFAULT_MAX_DURATION_MS: u64 = 30 * DAY_MS;
+    const DEFAULT_FEE_BPS: u64 = 50;
+
+    public struct InsuranceAdminCap has key, store {
+        id: UID,
+    }
+
+    public struct InsuranceConfig has key {
+        id: UID,
+        paused: bool,
+        min_coverage_bps: u64,
+        max_coverage_bps: u64,
+        max_duration_ms: u64,
+        fee_bps: u64,
+        treasury: address,
+        version: u64,
+    }
+
+    public struct UnderwriterVault has key {
+        id: UID,
+        underwriter: address,
+        capital: Balance<MYS>,
+        reserved: u64,
+        base_rate_bps_per_day: u64,
+        utilization_multiplier_bps: u64,
+        max_exposure_per_market: u64,
+        max_exposure_per_user: u64,
+        market_exposures: Table<address, MarketExposure>,
+        user_exposures: Table<address, u64>,
+        version: u64,
+    }
+
+    public struct MarketExposure has store, drop {
+        market_id: address,
+        total_reserved: u64,
+        reserved_by_option: Table<u8, u64>,
+    }
+
+    public struct CoveragePolicy has key {
+        id: UID,
+        market_id: address,
+        insured: address,
+        option_id: u8,
+        covered_amount: u64,
+        coverage_bps: u64,
+        premium_paid: u64,
+        start_time_ms: u64,
+        expiry_time_ms: u64,
+        vault_id: ID,
+        status: u8,
+    }
+
+    /// Events
+    public struct ConfigInitializedEvent has copy, drop {
+        admin: address,
+        min_coverage_bps: u64,
+        max_coverage_bps: u64,
+        max_duration_ms: u64,
+        fee_bps: u64,
+        treasury: address,
+    }
+
+    public struct VaultCreatedEvent has copy, drop {
+        vault_id: ID,
+        underwriter: address,
+        base_rate_bps_per_day: u64,
+        utilization_multiplier_bps: u64,
+        max_exposure_per_market: u64,
+        max_exposure_per_user: u64,
+    }
+
+    public struct VaultDepositedEvent has copy, drop {
+        vault_id: ID,
+        amount: u64,
+        new_balance: u64,
+    }
+
+    public struct VaultWithdrawnEvent has copy, drop {
+        vault_id: ID,
+        amount: u64,
+        new_balance: u64,
+    }
+
+    public struct CoveragePurchasedEvent has copy, drop {
+        policy_id: ID,
+        market_id: address,
+        insured: address,
+        option_id: u8,
+        covered_amount: u64,
+        coverage_bps: u64,
+        premium_paid: u64,
+        reserve_locked: u64,
+        expiry_time_ms: u64,
+    }
+
+    public struct CoverageCancelledEvent has copy, drop {
+        policy_id: ID,
+        insured: address,
+        refunded_amount: u64,
+        fee_paid: u64,
+    }
+
+    public struct CoverageClaimedEvent has copy, drop {
+        policy_id: ID,
+        insured: address,
+        payout: u64,
+    }
+
+    /// Initialize config
+    public entry fun init_config(
+        min_coverage_bps: u64,
+        max_coverage_bps: u64,
+        max_duration_ms: u64,
+        fee_bps: u64,
+        treasury: address,
+        ctx: &mut TxContext
+    ) {
+        assert!(min_coverage_bps > 0, EInvalidCoverage);
+        assert!(min_coverage_bps <= max_coverage_bps, EInvalidCoverage);
+        assert!(max_coverage_bps <= BPS_DENOM, EInvalidCoverage);
+        assert!(max_duration_ms > 0, EInvalidDuration);
+        assert!(fee_bps <= BPS_DENOM, EInvalidCoverage);
+
+        let admin = tx_context::sender(ctx);
+        transfer::share_object(InsuranceConfig {
+            id: object::new(ctx),
+            paused: false,
+            min_coverage_bps,
+            max_coverage_bps,
+            max_duration_ms,
+            fee_bps,
+            treasury,
+            version: DEFAULT_VERSION,
+        });
+        transfer::public_transfer(InsuranceAdminCap { id: object::new(ctx) }, admin);
+
+        event::emit(ConfigInitializedEvent {
+            admin,
+            min_coverage_bps,
+            max_coverage_bps,
+            max_duration_ms,
+            fee_bps,
+            treasury,
+        });
+    }
+
+    /// Update config (admin only)
+    public entry fun set_config(
+        _: &InsuranceAdminCap,
+        config: &mut InsuranceConfig,
+        min_coverage_bps: u64,
+        max_coverage_bps: u64,
+        max_duration_ms: u64,
+        fee_bps: u64,
+        treasury: address,
+        ctx: &mut TxContext
+    ) {
+        assert!(min_coverage_bps > 0, EInvalidCoverage);
+        assert!(min_coverage_bps <= max_coverage_bps, EInvalidCoverage);
+        assert!(max_coverage_bps <= BPS_DENOM, EInvalidCoverage);
+        assert!(max_duration_ms > 0, EInvalidDuration);
+        assert!(fee_bps <= BPS_DENOM, EInvalidCoverage);
+
+        config.min_coverage_bps = min_coverage_bps;
+        config.max_coverage_bps = max_coverage_bps;
+        config.max_duration_ms = max_duration_ms;
+        config.fee_bps = fee_bps;
+        config.treasury = treasury;
+        let _ = ctx;
+    }
+
+    /// Emergency pause toggle (admin only)
+    public entry fun set_paused(
+        _: &InsuranceAdminCap,
+        config: &mut InsuranceConfig,
+        paused: bool
+    ) {
+        config.paused = paused;
+    }
+
+    public(package) fun create_insurance_admin_cap(ctx: &mut TxContext): InsuranceAdminCap {
+        InsuranceAdminCap { id: object::new(ctx) }
+    }
+
+    public(package) fun bootstrap_init(ctx: &mut TxContext) {
+        let admin = tx_context::sender(ctx);
+        transfer::share_object(InsuranceConfig {
+            id: object::new(ctx),
+            paused: false,
+            min_coverage_bps: DEFAULT_MIN_COVERAGE_BPS,
+            max_coverage_bps: DEFAULT_MAX_COVERAGE_BPS,
+            max_duration_ms: DEFAULT_MAX_DURATION_MS,
+            fee_bps: DEFAULT_FEE_BPS,
+            treasury: admin,
+            version: DEFAULT_VERSION,
+        });
+    }
+
+    /// Create an underwriter vault
+    public entry fun create_vault(
+        base_rate_bps_per_day: u64,
+        utilization_multiplier_bps: u64,
+        max_exposure_per_market: u64,
+        max_exposure_per_user: u64,
+        ctx: &mut TxContext
+    ) {
+        let underwriter = tx_context::sender(ctx);
+        let vault = UnderwriterVault {
+            id: object::new(ctx),
+            underwriter,
+            capital: balance::zero(),
+            reserved: 0,
+            base_rate_bps_per_day,
+            utilization_multiplier_bps,
+            max_exposure_per_market,
+            max_exposure_per_user,
+            market_exposures: table::new(ctx),
+            user_exposures: table::new(ctx),
+            version: DEFAULT_VERSION,
+        };
+        let vault_id = object::id(&vault);
+        transfer::share_object(vault);
+
+        event::emit(VaultCreatedEvent {
+            vault_id,
+            underwriter,
+            base_rate_bps_per_day,
+            utilization_multiplier_bps,
+            max_exposure_per_market,
+            max_exposure_per_user,
+        });
+    }
+
+    /// Deposit capital into vault
+    public entry fun deposit_capital(
+        config: &InsuranceConfig,
+        vault: &mut UnderwriterVault,
+        payment: Coin<MYS>,
+        ctx: &mut TxContext
+    ) {
+        assert!(!config.paused, EPaused);
+        let deposit_amount = coin::value(&payment);
+        assert!(deposit_amount > 0, EInvalidAmount);
+        balance::join(&mut vault.capital, coin::into_balance(payment));
+        event::emit(VaultDepositedEvent {
+            vault_id: object::id(vault),
+            amount: deposit_amount,
+            new_balance: balance::value(&vault.capital),
+        });
+    }
+
+    /// Withdraw unreserved capital (underwriter only)
+    public entry fun withdraw_capital(
+        config: &InsuranceConfig,
+        vault: &mut UnderwriterVault,
+        amount: u64,
+        ctx: &mut TxContext
+    ) {
+        assert!(!config.paused, EPaused);
+        assert!(tx_context::sender(ctx) == vault.underwriter, ENotAdmin);
+        assert!(amount > 0, EInvalidAmount);
+
+        let capital_value = balance::value(&vault.capital);
+        assert!(capital_value >= vault.reserved, EOverflow);
+        let free_capital = capital_value - vault.reserved;
+        assert!(free_capital >= amount, EInsufficientCapital);
+
+        let payout_balance = balance::split(&mut vault.capital, amount);
+        let payout_coin = coin::from_balance(payout_balance, ctx);
+        transfer::public_transfer(payout_coin, vault.underwriter);
+
+        event::emit(VaultWithdrawnEvent {
+            vault_id: object::id(vault),
+            amount,
+            new_balance: balance::value(&vault.capital),
+        });
+    }
+
+    /// Quote premium based on vault utilization
+    public fun quote_premium(
+        vault: &UnderwriterVault,
+        covered_amount: u64,
+        coverage_bps: u64,
+        duration_ms: u64
+    ): u64 {
+        let capital_value = balance::value(&vault.capital);
+        let utilization_bps = if (capital_value == 0) {
+            BPS_DENOM
+        } else {
+            let utilization_u128 = (vault.reserved as u128) * (BPS_DENOM as u128) / (capital_value as u128);
+            assert!(utilization_u128 <= (MAX_U64 as u128), EOverflow);
+            utilization_u128 as u64
+        };
+        let utilization_factor = (utilization_bps * vault.utilization_multiplier_bps) / BPS_DENOM;
+        let total_rate_bps_per_day = vault.base_rate_bps_per_day + utilization_factor;
+
+        let numerator = (covered_amount as u128)
+            * (coverage_bps as u128)
+            * (total_rate_bps_per_day as u128)
+            * (duration_ms as u128);
+        let denominator = (BPS_DENOM as u128) * (BPS_DENOM as u128) * (DAY_MS as u128);
+        let premium_u128 = numerator / denominator;
+        assert!(premium_u128 <= (MAX_U64 as u128), EOverflow);
+        premium_u128 as u64
+    }
+
+    /// Buy coverage for a SPoT position
+    public entry fun buy_coverage(
+        config: &InsuranceConfig,
+        vault: &mut UnderwriterVault,
+        record: &spot::SpotRecord,
+        option_id: u8,
+        requested_coverage_amount: u64,
+        coverage_bps: u64,
+        duration_ms: u64,
+        mut payment: Coin<MYS>,
+        clock: &Clock,
+        ctx: &mut TxContext
+    ) {
+        assert!(!config.paused, EPaused);
+        assert!(spot::is_open(record), EMarketClosed);
+        assert!(coverage_bps >= config.min_coverage_bps, EInvalidCoverage);
+        assert!(coverage_bps <= config.max_coverage_bps, EInvalidCoverage);
+        assert!(duration_ms > 0 && duration_ms <= config.max_duration_ms, EInvalidDuration);
+        assert!(requested_coverage_amount > 0, EInvalidAmount);
+
+        let insured = tx_context::sender(ctx);
+        let market_id = spot::get_id_address(record);
+        let position_amount = spot::get_user_option_amount(record, insured, option_id);
+        let covered_amount = if (requested_coverage_amount <= position_amount) {
+            requested_coverage_amount
+        } else {
+            position_amount
+        };
+        assert!(covered_amount > 0, EInvalidAmount);
+
+        let reserve_amount = compute_reserve(covered_amount, coverage_bps);
+        let capital_value = balance::value(&vault.capital);
+        assert!(capital_value >= vault.reserved, EOverflow);
+        let free_capital = capital_value - vault.reserved;
+        assert!(free_capital >= reserve_amount, EInsufficientCapital);
+        assert!(vault.reserved <= MAX_U64 - reserve_amount, EOverflow);
+
+        enforce_exposure_limits(vault, market_id, insured, option_id, reserve_amount, ctx);
+
+        let premium = quote_premium(vault, covered_amount, coverage_bps, duration_ms);
+        assert!(premium > 0, EInsufficientPremium);
+        assert!(coin::value(&payment) >= premium, EInsufficientPremium);
+
+        let premium_coin = coin::split(&mut payment, premium, ctx);
+        balance::join(&mut vault.capital, coin::into_balance(premium_coin));
+
+        if (coin::value(&payment) > 0) {
+            transfer::public_transfer(payment, insured);
+        } else {
+            coin::destroy_zero(payment);
+        };
+
+        vault.reserved = vault.reserved + reserve_amount;
+        add_exposure(vault, market_id, insured, option_id, reserve_amount, ctx);
+
+        let now = clock::timestamp_ms(clock);
+        assert!(now <= MAX_U64 - duration_ms, EOverflow);
+        let expiry_time_ms = now + duration_ms;
+        let policy = CoveragePolicy {
+            id: object::new(ctx),
+            market_id,
+            insured,
+            option_id,
+            covered_amount,
+            coverage_bps,
+            premium_paid: premium,
+            start_time_ms: now,
+            expiry_time_ms,
+            vault_id: object::id(vault),
+            status: STATUS_ACTIVE,
+        };
+        let policy_id = object::id(&policy);
+        transfer::public_transfer(policy, insured);
+
+        event::emit(CoveragePurchasedEvent {
+            policy_id,
+            market_id,
+            insured,
+            option_id,
+            covered_amount,
+            coverage_bps,
+            premium_paid: premium,
+            reserve_locked: reserve_amount,
+            expiry_time_ms,
+        });
+    }
+
+    /// Cancel coverage while the market is open
+    public entry fun cancel_coverage(
+        config: &InsuranceConfig,
+        vault: &mut UnderwriterVault,
+        record: &spot::SpotRecord,
+        policy: &mut CoveragePolicy,
+        clock: &Clock,
+        ctx: &mut TxContext
+    ) {
+        assert!(!config.paused, EPaused);
+        assert!(spot::is_open(record), EMarketClosed);
+        assert!(policy.status == STATUS_ACTIVE, EPolicyNotActive);
+        assert!(tx_context::sender(ctx) == policy.insured, ENotPolicyOwner);
+        assert!(policy.market_id == spot::get_id_address(record), EMarketMismatch);
+        assert!(policy.vault_id == object::id(vault), EInvalidVault);
+
+        let now = clock::timestamp_ms(clock);
+        assert!(now < policy.expiry_time_ms, EPolicyExpired);
+
+        let total_duration = policy.expiry_time_ms - policy.start_time_ms;
+        let remaining = policy.expiry_time_ms - now;
+        let refund_u128 = (policy.premium_paid as u128) * (remaining as u128) / (total_duration as u128);
+        assert!(refund_u128 <= (MAX_U64 as u128), EOverflow);
+        let mut refund = refund_u128 as u64;
+
+        let fee = (refund * config.fee_bps) / BPS_DENOM;
+        let total_refund = refund;
+        let capital_value = balance::value(&vault.capital);
+        assert!(capital_value >= total_refund, EInsufficientCapital);
+        if (fee > 0) {
+            refund = refund - fee;
+            let fee_balance = balance::split(&mut vault.capital, fee);
+            let fee_coin = coin::from_balance(fee_balance, ctx);
+            transfer::public_transfer(fee_coin, config.treasury);
+        };
+
+        if (refund > 0) {
+            let refund_balance = balance::split(&mut vault.capital, refund);
+            let refund_coin = coin::from_balance(refund_balance, ctx);
+            transfer::public_transfer(refund_coin, policy.insured);
+        };
+
+        let reserve_amount = compute_reserve(policy.covered_amount, policy.coverage_bps);
+        release_exposure(vault, policy.market_id, policy.insured, policy.option_id, reserve_amount);
+        assert!(vault.reserved >= reserve_amount, EOverflow);
+        vault.reserved = vault.reserved - reserve_amount;
+        policy.status = STATUS_CANCELLED;
+
+        event::emit(CoverageCancelledEvent {
+            policy_id: object::id(policy),
+            insured: policy.insured,
+            refunded_amount: refund,
+            fee_paid: fee,
+        });
+    }
+
+    /// Claim payout after SPoT resolution
+    public entry fun claim(
+        config: &InsuranceConfig,
+        vault: &mut UnderwriterVault,
+        record: &spot::SpotRecord,
+        policy: &mut CoveragePolicy,
+        clock: &Clock,
+        ctx: &mut TxContext
+    ) {
+        assert!(!config.paused, EPaused);
+        assert!(policy.status == STATUS_ACTIVE, EPolicyNotActive);
+        assert!(tx_context::sender(ctx) == policy.insured, ENotPolicyOwner);
+        assert!(policy.market_id == spot::get_id_address(record), EMarketMismatch);
+        assert!(policy.vault_id == object::id(vault), EInvalidVault);
+        assert!(spot::is_resolved(record), EMarketClosed);
+
+        let now = clock::timestamp_ms(clock);
+        assert!(now <= policy.expiry_time_ms, EPolicyExpired);
+
+        let outcome_opt = spot::get_outcome(record);
+        assert!(option::is_some(outcome_opt), EMarketClosed);
+        let outcome = *option::borrow(outcome_opt);
+
+        let mut payout = 0;
+        if (outcome != spot::outcome_draw() && outcome != spot::outcome_unapplicable()) {
+            if (outcome != policy.option_id) {
+                let current_position = spot::get_user_option_amount(record, policy.insured, policy.option_id);
+                let eligible_amount = if (current_position < policy.covered_amount) {
+                    current_position
+                } else {
+                    policy.covered_amount
+                };
+                let payout_u128 = (eligible_amount as u128) * (policy.coverage_bps as u128) / (BPS_DENOM as u128);
+                assert!(payout_u128 <= (MAX_U64 as u128), EOverflow);
+                payout = payout_u128 as u64;
+            };
+        };
+
+        if (payout > 0) {
+            let payout_balance = balance::split(&mut vault.capital, payout);
+            let payout_coin = coin::from_balance(payout_balance, ctx);
+            transfer::public_transfer(payout_coin, policy.insured);
+        };
+
+        let reserve_amount = compute_reserve(policy.covered_amount, policy.coverage_bps);
+        release_exposure(vault, policy.market_id, policy.insured, policy.option_id, reserve_amount);
+        assert!(vault.reserved >= reserve_amount, EOverflow);
+        vault.reserved = vault.reserved - reserve_amount;
+        policy.status = STATUS_CLAIMED;
+
+        event::emit(CoverageClaimedEvent {
+            policy_id: object::id(policy),
+            insured: policy.insured,
+            payout,
+        });
+    }
+
+    /// Expire policy and release reserves
+    public entry fun expire_policy(
+        vault: &mut UnderwriterVault,
+        policy: &mut CoveragePolicy,
+        clock: &Clock
+    ) {
+        if (policy.status != STATUS_ACTIVE) {
+            return;
+        };
+        if (policy.vault_id != object::id(vault)) {
+            return;
+        };
+        let now = clock::timestamp_ms(clock);
+        if (now < policy.expiry_time_ms) {
+            return;
+        };
+
+        let reserve_amount = compute_reserve(policy.covered_amount, policy.coverage_bps);
+        release_exposure(vault, policy.market_id, policy.insured, policy.option_id, reserve_amount);
+        assert!(vault.reserved >= reserve_amount, EOverflow);
+        vault.reserved = vault.reserved - reserve_amount;
+        policy.status = STATUS_EXPIRED;
+    }
+
+    fun compute_reserve(covered_amount: u64, coverage_bps: u64): u64 {
+        let reserve_u128 = (covered_amount as u128) * (coverage_bps as u128);
+        let reserve_u128 = reserve_u128 / (BPS_DENOM as u128);
+        assert!(reserve_u128 <= (MAX_U64 as u128), EOverflow);
+        reserve_u128 as u64
+    }
+
+    fun enforce_exposure_limits(
+        vault: &mut UnderwriterVault,
+        market_id: address,
+        insured: address,
+        option_id: u8,
+        reserve_amount: u64,
+        ctx: &mut TxContext
+    ) {
+        if (vault.max_exposure_per_market > 0) {
+            let exposure = get_market_exposure_mut(vault, market_id, ctx);
+            assert!(exposure.total_reserved <= MAX_U64 - reserve_amount, EOverflow);
+            let new_total = exposure.total_reserved + reserve_amount;
+            assert!(new_total <= vault.max_exposure_per_market, EExposureLimit);
+        };
+        if (vault.max_exposure_per_user > 0) {
+            let current_user = get_user_exposure(vault, insured);
+            assert!(current_user <= MAX_U64 - reserve_amount, EOverflow);
+            let new_user = current_user + reserve_amount;
+            assert!(new_user <= vault.max_exposure_per_user, EExposureLimit);
+        };
+
+        let exposure = get_market_exposure_mut(vault, market_id, ctx);
+        let option_reserved = get_option_reserved(exposure, option_id);
+        assert!(option_reserved <= MAX_U64 - reserve_amount, EOverflow);
+    }
+
+    fun add_exposure(
+        vault: &mut UnderwriterVault,
+        market_id: address,
+        insured: address,
+        option_id: u8,
+        reserve_amount: u64,
+        ctx: &mut TxContext
+    ) {
+        let exposure = get_market_exposure_mut(vault, market_id, ctx);
+        assert!(exposure.total_reserved <= MAX_U64 - reserve_amount, EOverflow);
+        exposure.total_reserved = exposure.total_reserved + reserve_amount;
+        let option_reserved = get_option_reserved(exposure, option_id);
+        assert!(option_reserved <= MAX_U64 - reserve_amount, EOverflow);
+        let new_option_reserved = option_reserved + reserve_amount;
+        set_option_reserved(exposure, option_id, new_option_reserved);
+
+        let current_user = get_user_exposure(vault, insured);
+        assert!(current_user <= MAX_U64 - reserve_amount, EOverflow);
+        let new_user = current_user + reserve_amount;
+        set_user_exposure(vault, insured, new_user);
+    }
+
+    fun release_exposure(
+        vault: &mut UnderwriterVault,
+        market_id: address,
+        insured: address,
+        option_id: u8,
+        reserve_amount: u64
+    ) {
+        if (!table::contains(&vault.market_exposures, market_id)) {
+            return;
+        };
+        let exposure = table::borrow_mut(&mut vault.market_exposures, market_id);
+        if (exposure.total_reserved >= reserve_amount) {
+            exposure.total_reserved = exposure.total_reserved - reserve_amount;
+        };
+
+        if (table::contains(&exposure.reserved_by_option, option_id)) {
+            let current_option = *table::borrow(&exposure.reserved_by_option, option_id);
+            if (current_option >= reserve_amount) {
+                let option_ref = table::borrow_mut(&mut exposure.reserved_by_option, option_id);
+                *option_ref = current_option - reserve_amount;
+            };
+        };
+
+        if (table::contains(&vault.user_exposures, insured)) {
+            let current_user = *table::borrow(&vault.user_exposures, insured);
+            if (current_user >= reserve_amount) {
+                let user_ref = table::borrow_mut(&mut vault.user_exposures, insured);
+                *user_ref = current_user - reserve_amount;
+            };
+        };
+    }
+
+    fun get_market_exposure_mut(
+        vault: &mut UnderwriterVault,
+        market_id: address,
+        ctx: &mut TxContext
+    ): &mut MarketExposure {
+        if (!table::contains(&vault.market_exposures, market_id)) {
+            let exposure = MarketExposure {
+                market_id,
+                total_reserved: 0,
+                reserved_by_option: table::new(ctx),
+            };
+            table::add(&mut vault.market_exposures, market_id, exposure);
+        };
+        table::borrow_mut(&mut vault.market_exposures, market_id)
+    }
+
+    fun get_user_exposure(vault: &UnderwriterVault, insured: address): u64 {
+        if (table::contains(&vault.user_exposures, insured)) {
+            *table::borrow(&vault.user_exposures, insured)
+        } else {
+            0
+        }
+    }
+
+    fun set_user_exposure(vault: &mut UnderwriterVault, insured: address, amount: u64) {
+        if (table::contains(&vault.user_exposures, insured)) {
+            let user_ref = table::borrow_mut(&mut vault.user_exposures, insured);
+            *user_ref = amount;
+        } else {
+            table::add(&mut vault.user_exposures, insured, amount);
+        };
+    }
+
+    fun get_option_reserved(exposure: &MarketExposure, option_id: u8): u64 {
+        if (table::contains(&exposure.reserved_by_option, option_id)) {
+            *table::borrow(&exposure.reserved_by_option, option_id)
+        } else {
+            0
+        }
+    }
+
+    fun set_option_reserved(exposure: &mut MarketExposure, option_id: u8, amount: u64) {
+        if (table::contains(&exposure.reserved_by_option, option_id)) {
+            let option_ref = table::borrow_mut(&mut exposure.reserved_by_option, option_id);
+            *option_ref = amount;
+        } else {
+            table::add(&mut exposure.reserved_by_option, option_id, amount);
+        };
+    }
+}

--- a/crates/mys-framework/packages/mys-social/sources/insurance.move
+++ b/crates/mys-framework/packages/mys-social/sources/insurance.move
@@ -162,8 +162,9 @@ module social_contracts::insurance {
         payout: u64,
     }
 
-    /// Initialize config
-    public entry fun init_config(
+    /// Initialize config (package only)
+    /// Creates InsuranceConfig and transfers InsuranceAdminCap to caller.
+    public(package) fun init_config(
         min_coverage_bps: u64,
         max_coverage_bps: u64,
         max_duration_ms: u64,
@@ -240,16 +241,15 @@ module social_contracts::insurance {
 
     public(package) fun bootstrap_init(ctx: &mut TxContext) {
         let admin = tx_context::sender(ctx);
-        transfer::share_object(InsuranceConfig {
-            id: object::new(ctx),
-            paused: true,
-            min_coverage_bps: DEFAULT_MIN_COVERAGE_BPS,
-            max_coverage_bps: DEFAULT_MAX_COVERAGE_BPS,
-            max_duration_ms: DEFAULT_MAX_DURATION_MS,
-            fee_bps: DEFAULT_FEE_BPS,
-            treasury: admin,
-            version: DEFAULT_VERSION,
-        });
+        // Use init_config with default values to create config and transfer admin cap
+        init_config(
+            DEFAULT_MIN_COVERAGE_BPS,
+            DEFAULT_MAX_COVERAGE_BPS,
+            DEFAULT_MAX_DURATION_MS,
+            DEFAULT_FEE_BPS,
+            admin,
+            ctx
+        );
     }
 
     /// Create an underwriter vault

--- a/crates/mys-framework/packages/mys-social/sources/insurance.move
+++ b/crates/mys-framework/packages/mys-social/sources/insurance.move
@@ -180,7 +180,7 @@ module social_contracts::insurance {
         let admin = tx_context::sender(ctx);
         transfer::share_object(InsuranceConfig {
             id: object::new(ctx),
-            paused: false,
+            paused: true,
             min_coverage_bps,
             max_coverage_bps,
             max_duration_ms,

--- a/crates/mys-framework/packages/mys-social/sources/insurance.move
+++ b/crates/mys-framework/packages/mys-social/sources/insurance.move
@@ -39,6 +39,7 @@ module social_contracts::insurance {
     const EMarketMismatch: u64 = 13;
     const EExposureLimit: u64 = 14;
     const EInsufficientPremium: u64 = 15;
+    const EExposureInvariantBroken: u64 = 16;
 
     /// Status
     const STATUS_ACTIVE: u8 = 1;
@@ -85,13 +86,13 @@ module social_contracts::insurance {
         version: u64,
     }
 
-    public struct MarketExposure has store, drop {
+    public struct MarketExposure has store {
         market_id: address,
         total_reserved: u64,
         reserved_by_option: Table<u8, u64>,
     }
 
-    public struct CoveragePolicy has key {
+    public struct CoveragePolicy has key, store {
         id: UID,
         market_id: address,
         insured: address,
@@ -115,7 +116,7 @@ module social_contracts::insurance {
         treasury: address,
     }
 
-    public struct VaultCreatedEvent has copy, drop {
+    public struct UnderwriterVaultCreatedEvent has copy, drop {
         vault_id: ID,
         underwriter: address,
         base_rate_bps_per_day: u64,
@@ -124,13 +125,13 @@ module social_contracts::insurance {
         max_exposure_per_user: u64,
     }
 
-    public struct VaultDepositedEvent has copy, drop {
+    public struct UnderwriterVaultDepositedEvent has copy, drop {
         vault_id: ID,
         amount: u64,
         new_balance: u64,
     }
 
-    public struct VaultWithdrawnEvent has copy, drop {
+    public struct UnderwriterVaultWithdrawnEvent has copy, drop {
         vault_id: ID,
         amount: u64,
         new_balance: u64,
@@ -241,7 +242,7 @@ module social_contracts::insurance {
         let admin = tx_context::sender(ctx);
         transfer::share_object(InsuranceConfig {
             id: object::new(ctx),
-            paused: false,
+            paused: true,
             min_coverage_bps: DEFAULT_MIN_COVERAGE_BPS,
             max_coverage_bps: DEFAULT_MAX_COVERAGE_BPS,
             max_duration_ms: DEFAULT_MAX_DURATION_MS,
@@ -276,7 +277,7 @@ module social_contracts::insurance {
         let vault_id = object::id(&vault);
         transfer::share_object(vault);
 
-        event::emit(VaultCreatedEvent {
+        event::emit(UnderwriterVaultCreatedEvent {
             vault_id,
             underwriter,
             base_rate_bps_per_day,
@@ -297,7 +298,7 @@ module social_contracts::insurance {
         let deposit_amount = coin::value(&payment);
         assert!(deposit_amount > 0, EInvalidAmount);
         balance::join(&mut vault.capital, coin::into_balance(payment));
-        event::emit(VaultDepositedEvent {
+        event::emit(UnderwriterVaultDepositedEvent {
             vault_id: object::id(vault),
             amount: deposit_amount,
             new_balance: balance::value(&vault.capital),
@@ -324,7 +325,7 @@ module social_contracts::insurance {
         let payout_coin = coin::from_balance(payout_balance, ctx);
         transfer::public_transfer(payout_coin, vault.underwriter);
 
-        event::emit(VaultWithdrawnEvent {
+        event::emit(UnderwriterVaultWithdrawnEvent {
             vault_id: object::id(vault),
             amount,
             new_balance: balance::value(&vault.capital),
@@ -362,6 +363,7 @@ module social_contracts::insurance {
     /// Buy coverage for a SPoT position
     public entry fun buy_coverage(
         config: &InsuranceConfig,
+        spot_config: &spot::SpotConfig,
         vault: &mut UnderwriterVault,
         record: &spot::SpotRecord,
         option_id: u8,
@@ -373,6 +375,7 @@ module social_contracts::insurance {
         ctx: &mut TxContext
     ) {
         assert!(!config.paused, EPaused);
+        assert!(spot::is_enabled(spot_config), EMarketClosed);
         assert!(spot::is_open(record), EMarketClosed);
         assert!(coverage_bps >= config.min_coverage_bps, EInvalidCoverage);
         assert!(coverage_bps <= config.max_coverage_bps, EInvalidCoverage);
@@ -447,8 +450,10 @@ module social_contracts::insurance {
     }
 
     /// Cancel coverage while the market is open
+    /// Cancellation can result in 0 refund due to fee + rounding
     public entry fun cancel_coverage(
         config: &InsuranceConfig,
+        spot_config: &spot::SpotConfig,
         vault: &mut UnderwriterVault,
         record: &spot::SpotRecord,
         policy: &mut CoveragePolicy,
@@ -456,6 +461,7 @@ module social_contracts::insurance {
         ctx: &mut TxContext
     ) {
         assert!(!config.paused, EPaused);
+        assert!(spot::is_enabled(spot_config), EMarketClosed);
         assert!(spot::is_open(record), EMarketClosed);
         assert!(policy.status == STATUS_ACTIVE, EPolicyNotActive);
         assert!(tx_context::sender(ctx) == policy.insured, ENotPolicyOwner);
@@ -469,21 +475,22 @@ module social_contracts::insurance {
         let remaining = policy.expiry_time_ms - now;
         let refund_u128 = (policy.premium_paid as u128) * (remaining as u128) / (total_duration as u128);
         assert!(refund_u128 <= (MAX_U64 as u128), EOverflow);
-        let mut refund = refund_u128 as u64;
+        let original_refund = refund_u128 as u64;
 
-        let fee = (refund * config.fee_bps) / BPS_DENOM;
-        let total_refund = refund;
+        let fee = (original_refund * config.fee_bps) / BPS_DENOM;
+        let net_refund = original_refund - fee;
+        // original_refund == fee + net_refund; ensure vault can fund both splits
         let capital_value = balance::value(&vault.capital);
-        assert!(capital_value >= total_refund, EInsufficientCapital);
+        assert!(capital_value >= original_refund, EInsufficientCapital);
+        
         if (fee > 0) {
-            refund = refund - fee;
             let fee_balance = balance::split(&mut vault.capital, fee);
             let fee_coin = coin::from_balance(fee_balance, ctx);
             transfer::public_transfer(fee_coin, config.treasury);
         };
 
-        if (refund > 0) {
-            let refund_balance = balance::split(&mut vault.capital, refund);
+        if (net_refund > 0) {
+            let refund_balance = balance::split(&mut vault.capital, net_refund);
             let refund_coin = coin::from_balance(refund_balance, ctx);
             transfer::public_transfer(refund_coin, policy.insured);
         };
@@ -497,14 +504,18 @@ module social_contracts::insurance {
         event::emit(CoverageCancelledEvent {
             policy_id: object::id(policy),
             insured: policy.insured,
-            refunded_amount: refund,
+            refunded_amount: net_refund,
             fee_paid: fee,
         });
     }
 
     /// Claim payout after SPoT resolution
+    /// Payout is calculated as min(current_position, covered_amount) * coverage_bps / BPS_DENOM
+    /// Dynamic coverage: payout adjusts if user reduces their SPoT position after buying insurance.
+    /// This prevents exploitation where user buys insurance then exits bet.
     public entry fun claim(
         config: &InsuranceConfig,
+        spot_config: &spot::SpotConfig,
         vault: &mut UnderwriterVault,
         record: &spot::SpotRecord,
         policy: &mut CoveragePolicy,
@@ -512,6 +523,7 @@ module social_contracts::insurance {
         ctx: &mut TxContext
     ) {
         assert!(!config.paused, EPaused);
+        assert!(spot::is_enabled(spot_config), EMarketClosed);
         assert!(policy.status == STATUS_ACTIVE, EPolicyNotActive);
         assert!(tx_context::sender(ctx) == policy.insured, ENotPolicyOwner);
         assert!(policy.market_id == spot::get_id_address(record), EMarketMismatch);
@@ -528,6 +540,7 @@ module social_contracts::insurance {
         let mut payout = 0;
         if (outcome != spot::outcome_draw() && outcome != spot::outcome_unapplicable()) {
             if (outcome != policy.option_id) {
+                // Dynamic coverage: payout adjusts if user reduces their SPoT position after buying insurance
                 let current_position = spot::get_user_option_amount(record, policy.insured, policy.option_id);
                 let eligible_amount = if (current_position < policy.covered_amount) {
                     current_position
@@ -566,14 +579,14 @@ module social_contracts::insurance {
         clock: &Clock
     ) {
         if (policy.status != STATUS_ACTIVE) {
-            return;
+            return
         };
         if (policy.vault_id != object::id(vault)) {
-            return;
+            return
         };
         let now = clock::timestamp_ms(clock);
         if (now < policy.expiry_time_ms) {
-            return;
+            return
         };
 
         let reserve_amount = compute_reserve(policy.covered_amount, policy.coverage_bps);
@@ -598,20 +611,27 @@ module social_contracts::insurance {
         reserve_amount: u64,
         ctx: &mut TxContext
     ) {
-        if (vault.max_exposure_per_market > 0) {
-            let exposure = get_market_exposure_mut(vault, market_id, ctx);
-            assert!(exposure.total_reserved <= MAX_U64 - reserve_amount, EOverflow);
-            let new_total = exposure.total_reserved + reserve_amount;
-            assert!(new_total <= vault.max_exposure_per_market, EExposureLimit);
-        };
-        if (vault.max_exposure_per_user > 0) {
+        // Read limit values before creating mutable borrows
+        let max_exposure_per_market = vault.max_exposure_per_market;
+        let max_exposure_per_user = vault.max_exposure_per_user;
+        
+        // Check user exposure limit first (doesn't require market exposure)
+        if (max_exposure_per_user > 0) {
             let current_user = get_user_exposure(vault, insured);
             assert!(current_user <= MAX_U64 - reserve_amount, EOverflow);
             let new_user = current_user + reserve_amount;
-            assert!(new_user <= vault.max_exposure_per_user, EExposureLimit);
+            assert!(new_user <= max_exposure_per_user, EExposureLimit);
         };
 
+        // Now get mutable reference to market exposure for market and option checks
         let exposure = get_market_exposure_mut(vault, market_id, ctx);
+        
+        if (max_exposure_per_market > 0) {
+            assert!(exposure.total_reserved <= MAX_U64 - reserve_amount, EOverflow);
+            let new_total = exposure.total_reserved + reserve_amount;
+            assert!(new_total <= max_exposure_per_market, EExposureLimit);
+        };
+
         let option_reserved = get_option_reserved(exposure, option_id);
         assert!(option_reserved <= MAX_U64 - reserve_amount, EOverflow);
     }
@@ -645,29 +665,26 @@ module social_contracts::insurance {
         option_id: u8,
         reserve_amount: u64
     ) {
-        if (!table::contains(&vault.market_exposures, market_id)) {
-            return;
+        if (reserve_amount == 0) {
+            return
         };
+        
+        assert!(table::contains(&vault.market_exposures, market_id), EExposureInvariantBroken);
         let exposure = table::borrow_mut(&mut vault.market_exposures, market_id);
-        if (exposure.total_reserved >= reserve_amount) {
-            exposure.total_reserved = exposure.total_reserved - reserve_amount;
-        };
+        assert!(exposure.total_reserved >= reserve_amount, EExposureInvariantBroken);
+        exposure.total_reserved = exposure.total_reserved - reserve_amount;
 
-        if (table::contains(&exposure.reserved_by_option, option_id)) {
-            let current_option = *table::borrow(&exposure.reserved_by_option, option_id);
-            if (current_option >= reserve_amount) {
-                let option_ref = table::borrow_mut(&mut exposure.reserved_by_option, option_id);
-                *option_ref = current_option - reserve_amount;
-            };
-        };
+        assert!(table::contains(&exposure.reserved_by_option, option_id), EExposureInvariantBroken);
+        let current_option = *table::borrow(&exposure.reserved_by_option, option_id);
+        assert!(current_option >= reserve_amount, EExposureInvariantBroken);
+        let option_ref = table::borrow_mut(&mut exposure.reserved_by_option, option_id);
+        *option_ref = current_option - reserve_amount;
 
-        if (table::contains(&vault.user_exposures, insured)) {
-            let current_user = *table::borrow(&vault.user_exposures, insured);
-            if (current_user >= reserve_amount) {
-                let user_ref = table::borrow_mut(&mut vault.user_exposures, insured);
-                *user_ref = current_user - reserve_amount;
-            };
-        };
+        assert!(table::contains(&vault.user_exposures, insured), EExposureInvariantBroken);
+        let current_user = *table::borrow(&vault.user_exposures, insured);
+        assert!(current_user >= reserve_amount, EExposureInvariantBroken);
+        let user_ref = table::borrow_mut(&mut vault.user_exposures, insured);
+        *user_ref = current_user - reserve_amount;
     }
 
     fun get_market_exposure_mut(

--- a/crates/mys-framework/packages/mys-social/sources/social_proof_of_truth.move
+++ b/crates/mys-framework/packages/mys-social/sources/social_proof_of_truth.move
@@ -227,6 +227,9 @@ module social_contracts::social_proof_of_truth {
         }
     }
 
+    // Public getter for SpotConfig
+    public fun is_enabled(config: &SpotConfig): bool { config.enable_flag }
+
     // Bootstrap
     public(package) fun bootstrap_init(ctx: &mut TxContext) {
         let admin = tx_context::sender(ctx);

--- a/crates/mys-framework/packages/mys-social/sources/social_proof_of_truth.move
+++ b/crates/mys-framework/packages/mys-social/sources/social_proof_of_truth.move
@@ -118,6 +118,7 @@ module social_contracts::social_proof_of_truth {
         escrow: Balance<MYS>,
         betting_options: vector<String>,
         option_escrow: Table<u8, u64>,
+        user_option_amounts: Table<address, vector<u64>>,
         bets: vector<SpotBet>,
         resolution_window_epochs: Option<u64>,
         max_resolution_window_epochs: Option<u64>,
@@ -202,6 +203,27 @@ module social_contracts::social_proof_of_truth {
             *table::borrow(&rec.option_escrow, option_id)
         } else {
             0
+        }
+    }
+    public fun get_id_address(rec: &SpotRecord): address {
+        object::uid_to_address(&rec.id)
+    }
+    public fun get_outcome(rec: &SpotRecord): &Option<u8> { &rec.outcome }
+    public fun is_open(rec: &SpotRecord): bool { rec.status == STATUS_OPEN }
+    public fun is_resolved(rec: &SpotRecord): bool { rec.status == STATUS_RESOLVED }
+    public fun outcome_draw(): u8 { OUTCOME_DRAW }
+    public fun outcome_unapplicable(): u8 { OUTCOME_UNAPPLICABLE }
+    public fun get_user_option_amount(rec: &SpotRecord, user: address, option_id: u8): u64 {
+        if (!table::contains(&rec.user_option_amounts, user)) {
+            0
+        } else {
+            let amounts = table::borrow(&rec.user_option_amounts, user);
+            let idx = option_id as u64;
+            if (idx >= vector::length(amounts)) {
+                0
+            } else {
+                *vector::borrow(amounts, idx)
+            }
         }
     }
 
@@ -359,6 +381,7 @@ module social_contracts::social_proof_of_truth {
             escrow: balance::zero(),
             betting_options,
             option_escrow: table::new(ctx),
+            user_option_amounts: table::new(ctx),
             bets: vector::empty<SpotBet>(),
             resolution_window_epochs,
             max_resolution_window_epochs,
@@ -442,6 +465,18 @@ module social_contracts::social_proof_of_truth {
                 *escrow_ref = current_escrow - bet.amount;
             };
         };
+
+        if (table::contains(&record.user_option_amounts, bet.user)) {
+            let user_amounts = table::borrow_mut(&mut record.user_option_amounts, bet.user);
+            let idx = bet.option_id as u64;
+            if (idx < vector::length(user_amounts)) {
+                let current_user_amount = *vector::borrow(user_amounts, idx);
+                if (current_user_amount >= bet.amount) {
+                    let user_amount_ref = vector::borrow_mut(user_amounts, idx);
+                    *user_amount_ref = current_user_amount - bet.amount;
+                };
+            };
+        };
         
         // Remove bet from vector (swap with last and pop)
         let last_index = bets_len - 1;
@@ -513,6 +548,24 @@ module social_contracts::social_proof_of_truth {
             amount,
             timestamp: tx_context::epoch(ctx),
         });
+
+        let user = tx_context::sender(ctx);
+        let options_len = vector::length(&record.betting_options);
+        if (!table::contains(&record.user_option_amounts, user)) {
+            let mut amounts = vector::empty<u64>();
+            let mut i = 0;
+            while (i < options_len) {
+                vector::push_back(&mut amounts, 0);
+                i = i + 1;
+            };
+            table::add(&mut record.user_option_amounts, user, amounts);
+        };
+        let user_amounts = table::borrow_mut(&mut record.user_option_amounts, user);
+        let idx = option_id as u64;
+        let current_user_amount = *vector::borrow(user_amounts, idx);
+        assert!(current_user_amount <= MAX_U64 - amount, EOverflow);
+        let user_amount_ref = vector::borrow_mut(user_amounts, idx);
+        *user_amount_ref = current_user_amount + amount;
 
         event::emit(SpotBetPlacedEvent {
             post_id: post::get_id_address(post),

--- a/crates/mys-framework/packages/mys-social/tests/insurance_tests.move
+++ b/crates/mys-framework/packages/mys-social/tests/insurance_tests.move
@@ -1,0 +1,243 @@
+// Copyright (c) The Social Proof Foundation, LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+#[allow(unused_use, unused_variable, unused_assignment, duplicate_alias)]
+module social_contracts::insurance_tests {
+    use std::{string, option, vector};
+
+    use mys::test_scenario::{Self, Scenario};
+    use mys::tx_context;
+    use mys::coin::{Self, Coin};
+    use mys::clock::{Self, Clock};
+    use mys::transfer;
+    use mys::mys::MYS;
+
+    use social_contracts::insurance;
+    use social_contracts::social_proof_of_truth as spot;
+    use social_contracts::social_proof_tokens as spt;
+    use social_contracts::post::{Self, Post};
+    use social_contracts::platform::{Self, PlatformRegistry};
+    use social_contracts::block_list;
+
+    const ADMIN: address = @0xA0;
+    const CREATOR: address = @0xC1;
+    const UNDERWRITER: address = @0xB1;
+    const USER1: address = @0x01;
+
+    const SCALING: u64 = 1_000_000_000; // 1e9
+    const DAY_MS: u64 = 86_400_000;
+
+    fun setup_env(): Scenario {
+        let mut scen = test_scenario::begin(ADMIN);
+
+        spt::init_for_testing(test_scenario::ctx(&mut scen));
+
+        test_scenario::next_tx(&mut scen, ADMIN);
+        { block_list::test_init(test_scenario::ctx(&mut scen)); };
+
+        test_scenario::next_tx(&mut scen, ADMIN);
+        { platform::test_init(test_scenario::ctx(&mut scen)); };
+
+        test_scenario::next_tx(&mut scen, ADMIN);
+        { post::test_init(test_scenario::ctx(&mut scen)); };
+
+        test_scenario::next_tx(&mut scen, ADMIN);
+        { spot::test_init(test_scenario::ctx(&mut scen)); };
+
+        test_scenario::next_tx(&mut scen, ADMIN);
+        {
+            transfer_to(USER1, 10_000 * SCALING, test_scenario::ctx(&mut scen));
+            transfer_to(CREATOR, 10_000 * SCALING, test_scenario::ctx(&mut scen));
+            transfer_to(UNDERWRITER, 10_000 * SCALING, test_scenario::ctx(&mut scen));
+        };
+
+        test_scenario::next_tx(&mut scen, USER1);
+        {
+            let mut preg = test_scenario::take_shared<PlatformRegistry>(&scen);
+            platform::create_platform(
+                &mut preg,
+                string::utf8(b"Insurance Test Platform"),
+                string::utf8(b"Tag"),
+                string::utf8(b"Desc"),
+                string::utf8(b"https://logo"),
+                string::utf8(b"https://tos"),
+                string::utf8(b"https://pp"),
+                vector[string::utf8(b"web")],
+                vector[string::utf8(b"https://example")],
+                string::utf8(b"Social Network"),
+                option::none(),
+                3,
+                string::utf8(b"2024-01-01"),
+                false,
+                option::none(), option::none(), option::none(), option::none(),
+                option::none(), option::none(), option::none(), option::none(),
+                test_scenario::ctx(&mut scen)
+            );
+            test_scenario::return_shared(preg);
+        };
+
+        scen
+    }
+
+    fun transfer_to(to: address, amount: u64, ctx: &mut tx_context::TxContext) {
+        let c = coin::mint_for_testing<MYS>(amount, ctx);
+        transfer::public_transfer(c, to);
+    }
+
+    fun create_test_post(owner: address, ctx: &mut tx_context::TxContext): address {
+        post::test_create_post_with_spot(owner, owner, string::utf8(b"truth?"), ctx)
+    }
+
+    #[test]
+    fun test_buy_and_claim_insurance() {
+        let mut scen = setup_env();
+
+        test_scenario::next_tx(&mut scen, ADMIN);
+        {
+            insurance::init_config(
+                1000,
+                9000,
+                7 * DAY_MS,
+                50,
+                ADMIN,
+                test_scenario::ctx(&mut scen)
+            );
+        };
+
+        test_scenario::next_tx(&mut scen, CREATOR);
+        { create_test_post(CREATOR, test_scenario::ctx(&mut scen)); };
+
+        test_scenario::next_tx(&mut scen, ADMIN);
+        {
+            let oracle_admin_cap = test_scenario::take_from_sender<spot::SpotOracleAdminCap>(&scen);
+            let cfg = test_scenario::take_shared<spot::SpotConfig>(&scen);
+            let mut p = test_scenario::take_shared<Post>(&scen);
+            let mut betting_options = vector::empty<string::String>();
+            vector::push_back(&mut betting_options, string::utf8(b"Yes"));
+            vector::push_back(&mut betting_options, string::utf8(b"No"));
+            spot::create_spot_record_for_post(
+                &oracle_admin_cap,
+                &cfg,
+                &mut p,
+                betting_options,
+                option::none(),
+                option::some(0),
+                test_scenario::ctx(&mut scen)
+            );
+            test_scenario::return_to_sender(&scen, oracle_admin_cap);
+            test_scenario::return_shared(cfg);
+            test_scenario::return_shared(p);
+        };
+
+        test_scenario::next_tx(&mut scen, USER1);
+        {
+            let mut rec = test_scenario::take_shared<spot::SpotRecord>(&scen);
+            let post_ref = test_scenario::take_shared<Post>(&scen);
+            let spot_cfg = test_scenario::take_shared<spot::SpotConfig>(&scen);
+            let pay = coin::mint_for_testing<MYS>(1000 * SCALING, test_scenario::ctx(&mut scen));
+
+            spot::place_spot_bet(
+                &spot_cfg,
+                &mut rec,
+                &post_ref,
+                pay,
+                0,
+                1000 * SCALING,
+                test_scenario::ctx(&mut scen)
+            );
+
+            assert!(spot::get_user_option_amount(&rec, USER1, 0) == 1000 * SCALING, 1);
+
+            test_scenario::return_shared(rec);
+            test_scenario::return_shared(spot_cfg);
+            test_scenario::return_shared(post_ref);
+        };
+
+        test_scenario::next_tx(&mut scen, UNDERWRITER);
+        {
+            insurance::create_vault(25, 5000, 0, 0, test_scenario::ctx(&mut scen));
+        };
+
+        test_scenario::next_tx(&mut scen, UNDERWRITER);
+        {
+            let config = test_scenario::take_shared<insurance::InsuranceConfig>(&scen);
+            let mut vault = test_scenario::take_shared<insurance::UnderwriterVault>(&scen);
+            let deposit = coin::mint_for_testing<MYS>(5_000 * SCALING, test_scenario::ctx(&mut scen));
+            insurance::deposit_capital(&config, &mut vault, deposit, test_scenario::ctx(&mut scen));
+            test_scenario::return_shared(config);
+            test_scenario::return_shared(vault);
+        };
+
+        test_scenario::next_tx(&mut scen, USER1);
+        {
+            let config = test_scenario::take_shared<insurance::InsuranceConfig>(&scen);
+            let mut vault = test_scenario::take_shared<insurance::UnderwriterVault>(&scen);
+            let record = test_scenario::take_shared<spot::SpotRecord>(&scen);
+            let clock = test_scenario::take_shared<Clock>(&scen);
+            let payment = coin::mint_for_testing<MYS>(500 * SCALING, test_scenario::ctx(&mut scen));
+
+            insurance::buy_coverage(
+                &config,
+                &mut vault,
+                &record,
+                0,
+                1000 * SCALING,
+                8000,
+                3 * DAY_MS,
+                payment,
+                &clock,
+                test_scenario::ctx(&mut scen)
+            );
+
+            test_scenario::return_shared(config);
+            test_scenario::return_shared(vault);
+            test_scenario::return_shared(record);
+            test_scenario::return_shared(clock);
+        };
+
+        test_scenario::next_tx(&mut scen, ADMIN);
+        {
+            let oracle_admin_cap = test_scenario::take_from_sender<spot::SpotOracleAdminCap>(&scen);
+            let cfg = test_scenario::take_shared<spot::SpotConfig>(&scen);
+            let mut rec = test_scenario::take_shared<spot::SpotRecord>(&scen);
+            let post_ref = test_scenario::take_shared<Post>(&scen);
+            let mut evidence_urls = vector::empty<string::String>();
+            vector::push_back(&mut evidence_urls, string::utf8(b"https://example.com/evidence"));
+            spot::oracle_resolve(
+                &oracle_admin_cap,
+                &cfg,
+                &mut rec,
+                &post_ref,
+                1,
+                9000,
+                string::utf8(b"Test resolution"),
+                evidence_urls,
+                test_scenario::ctx(&mut scen)
+            );
+            test_scenario::return_to_sender(&scen, oracle_admin_cap);
+            test_scenario::return_shared(cfg);
+            test_scenario::return_shared(rec);
+            test_scenario::return_shared(post_ref);
+        };
+
+        test_scenario::next_tx(&mut scen, USER1);
+        {
+            let config = test_scenario::take_shared<insurance::InsuranceConfig>(&scen);
+            let mut vault = test_scenario::take_shared<insurance::UnderwriterVault>(&scen);
+            let record = test_scenario::take_shared<spot::SpotRecord>(&scen);
+            let clock = test_scenario::take_shared<Clock>(&scen);
+            let mut policy = test_scenario::take_from_sender<insurance::CoveragePolicy>(&scen);
+
+            insurance::claim(&config, &mut vault, &record, &mut policy, &clock, test_scenario::ctx(&mut scen));
+
+            test_scenario::return_shared(config);
+            test_scenario::return_shared(vault);
+            test_scenario::return_shared(record);
+            test_scenario::return_shared(clock);
+            test_scenario::return_to_sender(&scen, policy);
+        };
+
+        test_scenario::end(scen);
+    }
+}

--- a/crates/mys-framework/packages/mys-social/tests/insurance_tests.move
+++ b/crates/mys-framework/packages/mys-social/tests/insurance_tests.move
@@ -12,6 +12,7 @@ module social_contracts::insurance_tests {
     use mys::clock::{Self, Clock};
     use mys::transfer;
     use mys::mys::MYS;
+    use mys::object;
 
     use social_contracts::insurance;
     use social_contracts::social_proof_of_truth as spot;
@@ -44,6 +45,12 @@ module social_contracts::insurance_tests {
 
         test_scenario::next_tx(&mut scen, ADMIN);
         { spot::test_init(test_scenario::ctx(&mut scen)); };
+
+        test_scenario::next_tx(&mut scen, ADMIN);
+        {
+            let clock = clock::create_for_testing(test_scenario::ctx(&mut scen));
+            clock::share_for_testing(clock);
+        };
 
         test_scenario::next_tx(&mut scen, ADMIN);
         {
@@ -87,6 +94,87 @@ module social_contracts::insurance_tests {
 
     fun create_test_post(owner: address, ctx: &mut tx_context::TxContext): address {
         post::test_create_post_with_spot(owner, owner, string::utf8(b"truth?"), ctx)
+    }
+
+    // === Helper Functions ===
+
+    fun setup_env_with_insurance(): Scenario {
+        let mut scen = setup_env();
+        test_scenario::next_tx(&mut scen, ADMIN);
+        {
+            insurance::init_config(
+                1000,
+                9000,
+                7 * DAY_MS,
+                50,
+                ADMIN,
+                test_scenario::ctx(&mut scen)
+            );
+        };
+        scen
+    }
+
+    fun setup_vault_with_capital(scenario: &mut Scenario, capital_amount: u64) {
+        test_scenario::next_tx(scenario, UNDERWRITER);
+        {
+            insurance::create_vault(25, 5000, 0, 0, test_scenario::ctx(scenario));
+        };
+        test_scenario::next_tx(scenario, UNDERWRITER);
+        {
+            let config = test_scenario::take_shared<insurance::InsuranceConfig>(scenario);
+            let mut vault = test_scenario::take_shared<insurance::UnderwriterVault>(scenario);
+            let deposit = coin::mint_for_testing<MYS>(capital_amount, test_scenario::ctx(scenario));
+            insurance::deposit_capital(&config, &mut vault, deposit, test_scenario::ctx(scenario));
+            test_scenario::return_shared(config);
+            test_scenario::return_shared(vault);
+        };
+    }
+
+    fun create_open_market_with_bet(scenario: &mut Scenario, bettor: address, bet_amount: u64, option_id: u8) {
+        test_scenario::next_tx(scenario, CREATOR);
+        { create_test_post(CREATOR, test_scenario::ctx(scenario)); };
+
+        test_scenario::next_tx(scenario, ADMIN);
+        {
+            let oracle_admin_cap = test_scenario::take_from_sender<spot::SpotOracleAdminCap>(scenario);
+            let cfg = test_scenario::take_shared<spot::SpotConfig>(scenario);
+            let mut p = test_scenario::take_shared<Post>(scenario);
+            let mut betting_options = vector::empty<string::String>();
+            vector::push_back(&mut betting_options, string::utf8(b"Yes"));
+            vector::push_back(&mut betting_options, string::utf8(b"No"));
+            spot::create_spot_record_for_post(
+                &oracle_admin_cap,
+                &cfg,
+                &mut p,
+                betting_options,
+                option::none(),
+                option::some(0),
+                test_scenario::ctx(scenario)
+            );
+            test_scenario::return_to_sender(scenario, oracle_admin_cap);
+            test_scenario::return_shared(cfg);
+            test_scenario::return_shared(p);
+        };
+
+        test_scenario::next_tx(scenario, bettor);
+        {
+            let mut rec = test_scenario::take_shared<spot::SpotRecord>(scenario);
+            let post_ref = test_scenario::take_shared<Post>(scenario);
+            let spot_cfg = test_scenario::take_shared<spot::SpotConfig>(scenario);
+            let pay = coin::mint_for_testing<MYS>(bet_amount, test_scenario::ctx(scenario));
+            spot::place_spot_bet(
+                &spot_cfg,
+                &mut rec,
+                &post_ref,
+                pay,
+                option_id,
+                bet_amount,
+                test_scenario::ctx(scenario)
+            );
+            test_scenario::return_shared(rec);
+            test_scenario::return_shared(spot_cfg);
+            test_scenario::return_shared(post_ref);
+        };
     }
 
     #[test]
@@ -172,6 +260,7 @@ module social_contracts::insurance_tests {
         test_scenario::next_tx(&mut scen, USER1);
         {
             let config = test_scenario::take_shared<insurance::InsuranceConfig>(&scen);
+            let spot_config = test_scenario::take_shared<spot::SpotConfig>(&scen);
             let mut vault = test_scenario::take_shared<insurance::UnderwriterVault>(&scen);
             let record = test_scenario::take_shared<spot::SpotRecord>(&scen);
             let clock = test_scenario::take_shared<Clock>(&scen);
@@ -179,6 +268,7 @@ module social_contracts::insurance_tests {
 
             insurance::buy_coverage(
                 &config,
+                &spot_config,
                 &mut vault,
                 &record,
                 0,
@@ -191,6 +281,7 @@ module social_contracts::insurance_tests {
             );
 
             test_scenario::return_shared(config);
+            test_scenario::return_shared(spot_config);
             test_scenario::return_shared(vault);
             test_scenario::return_shared(record);
             test_scenario::return_shared(clock);
@@ -227,15 +318,214 @@ module social_contracts::insurance_tests {
             let mut vault = test_scenario::take_shared<insurance::UnderwriterVault>(&scen);
             let record = test_scenario::take_shared<spot::SpotRecord>(&scen);
             let clock = test_scenario::take_shared<Clock>(&scen);
-            let mut policy = test_scenario::take_from_sender<insurance::CoveragePolicy>(&scen);
+            let mut policy_id_opt = test_scenario::most_recent_id_for_sender<insurance::CoveragePolicy>(&scen);
+            assert!(option::is_some(&policy_id_opt), 1);
+            let policy_id = option::extract(&mut policy_id_opt);
+            let mut policy = test_scenario::take_from_sender_by_id<insurance::CoveragePolicy>(&scen, policy_id);
 
-            insurance::claim(&config, &mut vault, &record, &mut policy, &clock, test_scenario::ctx(&mut scen));
+            let spot_config = test_scenario::take_shared<spot::SpotConfig>(&scen);
+            insurance::claim(&config, &spot_config, &mut vault, &record, &mut policy, &clock, test_scenario::ctx(&mut scen));
+            test_scenario::return_shared(spot_config);
 
             test_scenario::return_shared(config);
             test_scenario::return_shared(vault);
             test_scenario::return_shared(record);
             test_scenario::return_shared(clock);
             test_scenario::return_to_sender(&scen, policy);
+        };
+
+        test_scenario::end(scen);
+    }
+
+    #[test]
+    fun test_cancel_coverage() {
+        let mut scen = setup_env_with_insurance();
+        create_open_market_with_bet(&mut scen, USER1, 1000 * SCALING, 0);
+        setup_vault_with_capital(&mut scen, 5_000 * SCALING);
+
+        // Buy coverage
+        test_scenario::next_tx(&mut scen, USER1);
+        {
+            let config = test_scenario::take_shared<insurance::InsuranceConfig>(&scen);
+            let spot_config = test_scenario::take_shared<spot::SpotConfig>(&scen);
+            let mut vault = test_scenario::take_shared<insurance::UnderwriterVault>(&scen);
+            let record = test_scenario::take_shared<spot::SpotRecord>(&scen);
+            let clock = test_scenario::take_shared<Clock>(&scen);
+            let payment = coin::mint_for_testing<MYS>(500 * SCALING, test_scenario::ctx(&mut scen));
+
+            insurance::buy_coverage(
+                &config,
+                &spot_config,
+                &mut vault,
+                &record,
+                0,
+                1000 * SCALING,
+                8000,
+                3 * DAY_MS,
+                payment,
+                &clock,
+                test_scenario::ctx(&mut scen)
+            );
+
+            test_scenario::return_shared(config);
+            test_scenario::return_shared(spot_config);
+            test_scenario::return_shared(vault);
+            test_scenario::return_shared(record);
+            test_scenario::return_shared(clock);
+        };
+
+        // Advance clock by 1 day (1/3 of policy duration)
+        test_scenario::next_tx(&mut scen, ADMIN);
+        {
+            let mut clock = test_scenario::take_shared<Clock>(&scen);
+            clock::increment_for_testing(&mut clock, DAY_MS);
+            test_scenario::return_shared(clock);
+        };
+
+        // Cancel coverage - should get 2/3 refund minus fee
+        test_scenario::next_tx(&mut scen, USER1);
+        {
+            let config = test_scenario::take_shared<insurance::InsuranceConfig>(&scen);
+            let mut vault = test_scenario::take_shared<insurance::UnderwriterVault>(&scen);
+            let record = test_scenario::take_shared<spot::SpotRecord>(&scen);
+            let clock = test_scenario::take_shared<Clock>(&scen);
+            let mut policy_id_opt = test_scenario::most_recent_id_for_sender<insurance::CoveragePolicy>(&scen);
+            assert!(option::is_some(&policy_id_opt), 1);
+            let policy_id = option::extract(&mut policy_id_opt);
+            let mut policy = test_scenario::take_from_sender_by_id<insurance::CoveragePolicy>(&scen, policy_id);
+
+            let spot_config = test_scenario::take_shared<spot::SpotConfig>(&scen);
+            insurance::cancel_coverage(
+                &config,
+                &spot_config,
+                &mut vault,
+                &record,
+                &mut policy,
+                &clock,
+                test_scenario::ctx(&mut scen)
+            );
+            test_scenario::return_shared(spot_config);
+
+            test_scenario::return_shared(config);
+            test_scenario::return_shared(vault);
+            test_scenario::return_shared(record);
+            test_scenario::return_shared(clock);
+            test_scenario::return_to_sender(&scen, policy);
+        };
+
+        test_scenario::end(scen);
+    }
+
+    #[test]
+    fun test_withdraw_capital() {
+        let mut scen = setup_env_with_insurance();
+        setup_vault_with_capital(&mut scen, 5_000 * SCALING);
+
+        // Withdraw some unreserved capital
+        test_scenario::next_tx(&mut scen, UNDERWRITER);
+        {
+            let config = test_scenario::take_shared<insurance::InsuranceConfig>(&scen);
+            let mut vault = test_scenario::take_shared<insurance::UnderwriterVault>(&scen);
+            insurance::withdraw_capital(
+                &config,
+                &mut vault,
+                2_000 * SCALING,
+                test_scenario::ctx(&mut scen)
+            );
+            test_scenario::return_shared(config);
+            test_scenario::return_shared(vault);
+        };
+
+        test_scenario::end(scen);
+    }
+
+    #[test]
+    fun test_expire_policy() {
+        let mut scen = setup_env_with_insurance();
+        create_open_market_with_bet(&mut scen, USER1, 1000 * SCALING, 0);
+        setup_vault_with_capital(&mut scen, 5_000 * SCALING);
+
+        // Buy coverage with 1 day duration
+        test_scenario::next_tx(&mut scen, USER1);
+        {
+            let config = test_scenario::take_shared<insurance::InsuranceConfig>(&scen);
+            let spot_config = test_scenario::take_shared<spot::SpotConfig>(&scen);
+            let mut vault = test_scenario::take_shared<insurance::UnderwriterVault>(&scen);
+            let record = test_scenario::take_shared<spot::SpotRecord>(&scen);
+            let clock = test_scenario::take_shared<Clock>(&scen);
+            let payment = coin::mint_for_testing<MYS>(500 * SCALING, test_scenario::ctx(&mut scen));
+
+            insurance::buy_coverage(
+                &config,
+                &spot_config,
+                &mut vault,
+                &record,
+                0,
+                1000 * SCALING,
+                8000,
+                DAY_MS,
+                payment,
+                &clock,
+                test_scenario::ctx(&mut scen)
+            );
+
+            test_scenario::return_shared(config);
+            test_scenario::return_shared(spot_config);
+            test_scenario::return_shared(vault);
+            test_scenario::return_shared(record);
+            test_scenario::return_shared(clock);
+        };
+
+        // Advance clock past expiry time
+        test_scenario::next_tx(&mut scen, ADMIN);
+        {
+            let mut clock = test_scenario::take_shared<Clock>(&scen);
+            clock::increment_for_testing(&mut clock, DAY_MS + 1000); // 1 day + 1 second
+            test_scenario::return_shared(clock);
+        };
+
+        // Expire the policy
+        test_scenario::next_tx(&mut scen, USER1);
+        {
+            let mut vault = test_scenario::take_shared<insurance::UnderwriterVault>(&scen);
+            let clock = test_scenario::take_shared<Clock>(&scen);
+            let mut policy_id_opt = test_scenario::most_recent_id_for_sender<insurance::CoveragePolicy>(&scen);
+            assert!(option::is_some(&policy_id_opt), 1);
+            let policy_id = option::extract(&mut policy_id_opt);
+            let mut policy = test_scenario::take_from_sender_by_id<insurance::CoveragePolicy>(&scen, policy_id);
+
+            insurance::expire_policy(&mut vault, &mut policy, &clock);
+
+            test_scenario::return_shared(vault);
+            test_scenario::return_to_sender(&scen, policy);
+            test_scenario::return_shared(clock);
+        };
+
+        test_scenario::end(scen);
+    }
+
+    #[test]
+    fun test_quote_premium() {
+        let mut scen = setup_env_with_insurance();
+        setup_vault_with_capital(&mut scen, 5_000 * SCALING);
+
+        test_scenario::next_tx(&mut scen, ADMIN);
+        {
+            let vault = test_scenario::take_shared<insurance::UnderwriterVault>(&scen);
+            
+            // Test basic premium calculation
+            let premium1 = insurance::quote_premium(&vault, 1000 * SCALING, 8000, DAY_MS);
+            assert!(premium1 > 0, 1);
+
+            // Test longer duration = higher premium
+            let premium2 = insurance::quote_premium(&vault, 1000 * SCALING, 8000, 2 * DAY_MS);
+            assert!(premium2 > premium1, 2);
+
+            // Test higher coverage = higher premium
+            let premium3 = insurance::quote_premium(&vault, 2000 * SCALING, 8000, DAY_MS);
+            assert!(premium3 > premium1, 3);
+
+            test_scenario::return_shared(vault);
         };
 
         test_scenario::end(scen);

--- a/crates/mys-framework/packages/mys-social/tests/insurance_tests.move
+++ b/crates/mys-framework/packages/mys-social/tests/insurance_tests.move
@@ -119,6 +119,15 @@ module social_contracts::insurance_tests {
         {
             insurance::create_vault(25, 5000, 0, 0, test_scenario::ctx(scenario));
         };
+        // Unpause the config before depositing capital
+        test_scenario::next_tx(scenario, ADMIN);
+        {
+            let admin_cap = test_scenario::take_from_sender<insurance::InsuranceAdminCap>(scenario);
+            let mut config = test_scenario::take_shared<insurance::InsuranceConfig>(scenario);
+            insurance::set_paused(&admin_cap, &mut config, false);
+            test_scenario::return_shared(config);
+            test_scenario::return_to_sender(scenario, admin_cap);
+        };
         test_scenario::next_tx(scenario, UNDERWRITER);
         {
             let config = test_scenario::take_shared<insurance::InsuranceConfig>(scenario);
@@ -245,6 +254,16 @@ module social_contracts::insurance_tests {
         test_scenario::next_tx(&mut scen, UNDERWRITER);
         {
             insurance::create_vault(25, 5000, 0, 0, test_scenario::ctx(&mut scen));
+        };
+
+        // Unpause the config before depositing capital
+        test_scenario::next_tx(&mut scen, ADMIN);
+        {
+            let admin_cap = test_scenario::take_from_sender<insurance::InsuranceAdminCap>(&scen);
+            let mut config = test_scenario::take_shared<insurance::InsuranceConfig>(&scen);
+            insurance::set_paused(&admin_cap, &mut config, false);
+            test_scenario::return_shared(config);
+            test_scenario::return_to_sender(&scen, admin_cap);
         };
 
         test_scenario::next_tx(&mut scen, UNDERWRITER);


### PR DESCRIPTION
### Motivation
- Replace a hardcoded/admin address on the insurance config with a proper admin capability to match other modules and make the insurance module bootstrappable.
- Provide an emergency shutoff so insurance flows can be paused during incidents.
- Ensure insurance logic is callable from the global bootstrap flow and a minted admin cap is transferred to the bootstrap claimant.
- Expose SPoT per-user exposure bookkeeping to enable correct O(1) insured amount lookups used by the insurance module.

### Description
- Introduced `InsuranceAdminCap` and removed the `admin: address` field from `InsuranceConfig`, and updated `init_config` to mint and transfer an admin cap via `transfer::public_transfer`.
- Added `set_paused` (admin-only) and changed `set_config` to require `&InsuranceAdminCap` instead of checking a sender address, and added `bootstrap_init` + `create_insurance_admin_cap` so the module can be initialized in the global bootstrap flow.
- Enforced the emergency pause checks (`assert!(!config.paused, EPaused)`) in critical entrypoints (`deposit_capital`, `withdraw_capital`, `buy_coverage`, `cancel_coverage`, `claim`) and updated `claim` signature to accept `&InsuranceConfig`.
- Added per-user exposure bookkeeping to `SpotRecord` (`user_option_amounts`) with accessor helpers (`get_user_option_amount`, `get_id_address`, `get_outcome`, `is_open`, `is_resolved`, `outcome_draw`, `outcome_unapplicable`) and updated bet placement/withdrawal to maintain those counts, and added the insurance integration test file `tests/insurance_tests.move` (and updated its `claim` call to pass the config).

### Testing
- Added the integration test `crates/mys-framework/packages/mys-social/tests/insurance_tests.move` that exercises config initialization, vault creation/deposit, buy flow, SPoT resolution, and claim flows, but it was not executed as part of this change.
- No automated test runs were performed during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954637c9ad0832abeba4ef68da0d888)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new modules and integrates them across the stack.
> 
> - **Insurance**: New `social_contracts::insurance` module with `InsuranceAdminCap`, `InsuranceConfig` (pauseable), underwriter `vaults`, premium quoting, `buy_coverage`, `cancel_coverage`, `claim`, `expire_policy`, exposure limits, reserve accounting, and events
> - **Bootstrap**: Includes `social_contracts::insurance::bootstrap_init` and transfers `InsuranceAdminCap` in `claim_all_admin_capabilities`
> - **SPoT updates**: `SpotRecord` gains `user_option_amounts` and helpers (`get_user_option_amount`, `get_id_address`, `get_outcome`, `is_open`, `is_resolved`, `outcome_draw`, `outcome_unapplicable`) and updates bet placement/withdrawal to maintain per-user amounts
> - **Enclave**: New `social_contracts::enclave` module with `EnclaveConfig`, `Enclave`, `Cap`, PCR validation, Nitro attestation public key extraction, signature verification, and config updates
> - **Tests**: Adds `tests/insurance_tests.move` covering config, vault deposit/withdrawal, buy/cancel/claim/expire flows and premium quoting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a53ac1e50cf047fecba2c4c822b533cffa1ed54a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->